### PR TITLE
chore: update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 module.exports = {
-  parser: "babel-eslint",
+  parser: "@babel/eslint-parser",
   parserOptions: {
     sourceType: "module",
-    allowImportExportEverywhere: true
+    allowImportExportEverywhere: true,
   },
   extends: [
     "airbnb",
@@ -16,60 +16,70 @@ module.exports = {
     "plugin:promise/recommended",
     "plugin:prettier/recommended",
     "prettier",
-    "prettier/react"
   ],
   env: {
     browser: true,
-    node: true
+    node: true,
   },
   rules: {
+    "arrow-body-style": 0,
     camelcase: 0,
     curly: ["error", "all"],
+    "consistent-return": "error",
     "no-restricted-imports": [
       "error",
       {
         paths: [
           {
             name: "rebass",
-            message: "Please use rebass/styled-components instead."
-          }
-        ]
-      }
+            message: "Please use rebass/styled-components instead.",
+          },
+        ],
+      },
     ],
-    // 'prettier/prettier': 0,
+    "promise/always-return": 0,
     "react/boolean-prop-naming": [
       "error",
-      { rule: "^(is|has|will|(.*)On)[A-Z]([A-Za-z0-9]?)+" }
+      { rule: "^(is|has|will|(.*)On)[A-Z]([A-Za-z0-9]?)+" },
     ],
     "react/forbid-prop-types": 0,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "react/jsx-filename-extension": ["error", { extensions: [".js", ".jsx"] }],
     "react/jsx-props-no-spreading": 0,
-    "react/jsx-sort-props": "error",
+    "react/jsx-sort-props": ["error", { ignoreCase: true }],
     "react/no-array-index-key": 0,
     "react/no-did-mount-set-state": 0,
     "react/prefer-stateless-function": 0,
     "react/require-default-props": 0,
     "react/sort-prop-types": "error",
-    "react/state-in-constructor": ['error', 'never'],
-    'react/static-property-placement': ['error', 'static public field'],
+    "react/state-in-constructor": ["error", "never"],
+    "react/static-property-placement": ["error", "static public field"],
     "react/style-prop-object": 0,
     "import/no-extraneous-dependencies": 0,
     "import/prefer-default-export": 0,
     "import/order": [
-      "warn",
+      "error",
       {
-        groups: [
-          ["external", "builtin"],
-          ["internal", "index", "sibling", "parent"]
+        groups: ["builtin", "external", "internal"],
+        pathGroups: [
+          {
+            pattern: "react",
+            group: "external",
+            position: "before",
+          },
         ],
-        "newlines-between": "never"
-      }
+        pathGroupsExcludedImportTypes: ["react"],
+        "newlines-between": "always",
+        alphabetize: {
+          order: "asc",
+          caseInsensitive: true,
+        },
+      },
     ],
     "jsdoc/match-description": [
       "warn",
-      { matchDescription: "^(.* - )([A-Z]|[`\\d_])([\\s\\S]*[.?!`])?$" }
+      { matchDescription: "^(.* - )([A-Z]|[`\\d_])([\\s\\S]*[.?!`])?$" },
     ],
     "jsx-a11y/anchor-is-valid": ["error", { components: [] }],
     "jsx-a11y/no-static-element-interactions": 0,
@@ -80,16 +90,16 @@ module.exports = {
       {
         components: ["Label"],
         required: {
-          every: ["id"]
+          every: ["id"],
         },
-        allowChildren: false
-      }
+        allowChildren: false,
+      },
     ],
     "jsx-a11y/label-has-associated-control": [
       2,
       {
-        depth: 1
-      }
+        depth: 1,
+      },
     ],
     "max-len": ["error", { code: 120, ignoreUrls: true }],
     "no-cond-assign": ["error", "except-parens"],
@@ -103,20 +113,39 @@ module.exports = {
       "error",
       {
         array: false,
-        object: true
-      }
+        object: true,
+      },
     ],
-    "prefer-promise-reject-errors": 0
+    "prefer-promise-reject-errors": 0,
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        vars: "all",
+        varsIgnorePattern: "^_",
+        args: "after-used",
+        argsIgnorePattern: "^_",
+      },
+    ],
   },
   plugins: [
+    "compat",
     "import",
     "json",
+    "jsdoc",
     "markdown",
     "prettier",
     "promise",
-    "compat",
-    "jsdoc",
     "react",
-    "react-hooks"
-  ]
+    "react-hooks",
+    "unused-imports",
+  ],
+  settings: {
+    polyfills: ["Promise"],
+    "import/resolver": {
+      node: {
+        paths: ["src"],
+      },
+    },
+  },
 };

--- a/index.js
+++ b/index.js
@@ -45,9 +45,12 @@ module.exports = {
     "react/forbid-prop-types": 0,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
+    "react/jsx-curly-newline": 0,
     "react/jsx-filename-extension": ["error", { extensions: [".js", ".jsx"] }],
+    "react/jsx-one-expression-per-line": 0,
     "react/jsx-props-no-spreading": 0,
     "react/jsx-sort-props": ["error", { ignoreCase: true }],
+    "react/jsx-wrap-multilines": 0,
     "react/no-array-index-key": 0,
     "react/no-did-mount-set-state": 0,
     "react/prefer-stateless-function": 0,
@@ -109,6 +112,7 @@ module.exports = {
     "no-param-reassign": ["error", { props: false }],
     "no-new": 0,
     "no-tabs": "error",
+    "no-unused-vars": 0,
     "prefer-destructuring": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -18,25 +18,25 @@
     "url": "https://github.com/LN-Zap/zap-eslint-config/issues"
   },
   "homepage": "https://github.com/LN-Zap/zap-eslint-config",
-  "dependencies": {
-    "eslint-config-airbnb": "18.0.1",
-    "eslint-config-prettier": "6.5.0"
-  },
   "peerDependencies": {
-    "babel-eslint": "10.0.3",
-    "eslint": ">= 6",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "@babel/core": "^7.14.6",
+    "@babel/eslint-parser": "^7.14.7",
+    "eslint": "^7.29.0",
+    "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-formatter-pretty": "^2.1.1",
     "eslint-plugin-compat": "^3.3.0",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^23.0.2",
     "eslint-plugin-jsdoc": "^17.0.1",
     "eslint-plugin-json": "^2.0.1",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-markdown": "^1.0.1",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.16.0",
-    "eslint-plugin-react-hooks": "^2.2.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-unused-imports": "^1.1.1",
     "prettier": ">= 1"
   }
 }


### PR DESCRIPTION
The goal of this is to get all of the JS projects to use this shared eslint-config. This updates several dependencies and adds some new rules that have been in use in the web apps (mostly the extension).

Biggest changes
- `eslint` v7
- `babel-eslint` => `@babel/core + @babel/eslint-parser`
- Moved `eslint-config-airbnb`and `eslint-config-prettier` to `peerDependencies` too

These changes should probably be released under a major version bump